### PR TITLE
Upstream changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,20 +5,20 @@
     <packaging>jar</packaging>
     <version>71-jenkins-12-SNAPSHOT</version>
     <name>CvsClient</name>
-    <description>Netbeans cvsclient library patched for serialization and synchronization</description>
+    <description>NetBeans cvsclient library patched for serialization and synchronization</description>
     <licenses>
        <license>
            <url>http://www.netbeans.org/cddl-gplv2.html</url>
        </license>
     </licenses>
-    <distributionManagement>
+    <distributionManagement> <!-- TODO pick up from org.jenkins-ci:jenkins -->
         <repository>
-          <id>maven.jenkins-ci.org</id>
-          <url>http://maven.jenkins-ci.org:8081/content/repositories/releases</url>
+            <id>maven.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </repository>
         <snapshotRepository>
-          <id>maven.jenkins-ci.org</id>
-          <url>http://maven.jenkins-ci.org:8081/content/repositories/snapshots</url>
+            <id>maven.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -61,18 +61,5 @@
         </plugin>
       </plugins>
     </build>
-
-    <repositories>
-        <repository>
-          <id>maven.jenkins-ci.org</id>
-          <url>http://maven.jenkins-ci.org/content/groups/artifacts/</url>
-            <releases>
-               <enabled>true</enabled>
-            </releases>
-            <snapshots>
-               <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.50</version>
+            <version>0.1.54</version>
         </dependency>
     </dependencies>
     

--- a/src/main/java/org/netbeans/lib/cvsclient/command/annotate/AnnotateBuilder.java
+++ b/src/main/java/org/netbeans/lib/cvsclient/command/annotate/AnnotateBuilder.java
@@ -45,6 +45,8 @@ package org.netbeans.lib.cvsclient.command.annotate;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.netbeans.lib.cvsclient.command.BasicCommand;
 import org.netbeans.lib.cvsclient.command.Builder;
@@ -142,7 +144,13 @@ public class AnnotateBuilder implements Builder {
         if ((indexOpeningBracket > 0) && (indexClosingBracket > indexOpeningBracket)) {
             final String revision = line.substring(0, indexOpeningBracket).trim();
             final String userDate = line.substring(indexOpeningBracket + 1, indexClosingBracket);
-            final String contents = line.substring(indexClosingBracket + 3);
+            final String contents;
+            if (line.length() < indexClosingBracket + 3) {
+                contents = "";
+                Logger.getLogger(AnnotateBuilder.class.getName()).log(Level.WARNING, "processLine: line: {0}", line); //NOI18N
+            } else {
+                contents = line.substring(indexClosingBracket + 3);
+            }
             final int lastSpace = userDate.lastIndexOf(' ');
             String user = userDate;
             String date = userDate;


### PR DESCRIPTION
I did

```bash
hg arch -rrelease71_base -I lib.cvsclient /tmp/cvsclient-71
# last main-silver rev pushed, in Oct 2017:
hg arch -rfcaaa60addf7 -I lib.cvsclient /tmp/cvsclient-tip
cd /tmp
diff -u -N -r -w -I '^[ /]\*' -I '^ *$' -I '^#' cvsclient-71 cvsclient-tip > changes.diff
```

then manually deleted uninteresting hunks, applied what I could with `patch`, skipped over things already applied by @mc1arke in various backports, and reverted stuff specific to the NB test system. This is what was left. I have no comment on the quality or importance of these changes, just filing for the record.